### PR TITLE
Better parsing

### DIFF
--- a/lib/p2pbuffer.js
+++ b/lib/p2pbuffer.js
@@ -3,20 +3,26 @@
 var bignum = require('bignum');
 var crypto = require('crypto');
 var util = require('util');
+var inherits = require('util').inherits;
 var _ = require('lodash');
 
 var P2PBuffer = function() {
-  this.constructor.super_.apply(this, arguments)
+  function F(args) {
+    return Buffer.apply(this, args);
+  }
 
+  var b = new F(arguments);
+  Object.setPrototypeOf(b, P2PBuffer.prototype);
+  return b;
 };
 
-util.inherits(P2PBuffer, Buffer);
+P2PBuffer.prototype.__proto__ = Buffer.prototype;
+P2PBuffer.__proto__ = Buffer;
 
 P2PBuffer.prototype.writeInt64 = function(value, offset) {
   offset  = offset || 0;
-
   var x = bignum(value);
-  x.toBuffer({endian : 'little', size: 8}).copy(offset, 0, 8);
+  x.toBuffer({endian : 'little', size: 8}).copy(this, offset, 0, 8);
 }
 
 P2PBuffer.prototype.readInt64 = function(offset) {
@@ -25,7 +31,7 @@ P2PBuffer.prototype.readInt64 = function(offset) {
   return x.toNumber();
 }
 
-P2PBuffer.prototype.writeAddr = function(isVersion, addr, port, offset) {
+P2PBuffer.prototype.writeAddr = function(addr, port, offset) {
   offset  = offset || 0;
 
   var buffer = new Buffer(26);
@@ -35,18 +41,18 @@ P2PBuffer.prototype.writeAddr = function(isVersion, addr, port, offset) {
   return 26;
 }
 
-P2PBuffer.prototype.readAddr = function(isVersion, offset) {
+P2PBuffer.prototype.readAddr = function(offset) {
   offset  = offset || 0;
-  
-  var i = isVersion ? offset : offset + 4;
-  
+
+  var i = offset;
+
   var addr = {
     services:  this.readInt64(i),
     port:      this.readUInt16BE(i + 8 + 16)
   };
 
   var ip = this.slice(i + 8, i + 8 + 16);
-  
+
   addr.ipv4 = util.format("%d.%d.%d.%d", ip[12], ip[13], ip[14], ip[15]);
 
   return addr;

--- a/lib/p2psocket.js
+++ b/lib/p2psocket.js
@@ -9,13 +9,32 @@ var crypto = require('crypto');
 var util = require('util');
 var bs58 = require('bs58');
 
-var P2PSocket = function(magic, version) {
+function inPlaceReverse(buf, copy) {
+  var end = buf.length;
+  var i, h = Math.ceil(end/2), ii, tmp;
+
+  var original = buf;
+  var buf = new Buffer(buf.length);
+  original.copy(buf);
+
+  for ( i=0; i<h; i++ ) {
+    ii      = end-i-1;
+    tmp     = buf[i];
+    buf[i]  = buf[ii];
+    buf[ii] = tmp;
+  }
+
+  return buf;
+}
+
+var P2PSocket = function(magic, version, divisor) {
   this.constructor.super_.apply(this)
 
   this._nonce = 1;
 
   this._magic   = magic;
   this._version = version || 0x6f;
+  this._divisor = divisor || 100000000;
 
   var _super_connect = this.connect;
 
@@ -82,35 +101,73 @@ P2PSocket.prototype.parseInv = function(payload) {
     var offset = size + i * 36;
     content.inventory.push({
       type: payload.readUInt32LE(offset),
-      hash: payload.slice(offset + 4, offset + 4 + 32)
+      hash: inPlaceReverse(payload.slice(offset + 4, offset + 4 + 32)).toString('hex')
     });
   }
 
   return content;
 }
 
-function inPlaceReverse(buf) {
-  var i, h = Math.ceil(buf.length/2), ii, tmp;
+P2PSocket.prototype.parseBlock = function(payload) {
 
-  for ( i=0; i<h; i++ ) {
-    ii      = buf.length-i-1;
-    tmp     = buf[i];
-    buf[i]  = buf[ii];
-    buf[ii] = tmp;
+  var header = payload.slice(0,80);
+
+  var sha256_pass1 = crypto.createHash('sha256').update(header).digest();
+  var blockhash = inPlaceReverse(crypto.createHash('sha256').update(sha256_pass1).digest()).toString('hex');
+
+  var content = {
+    hash:              blockhash,
+    confirmations:     undefined,
+    size:              payload.length,
+    height:            undefined,
+    version:           payload.readUInt32LE(0),
+    merkleroot:        inPlaceReverse(payload.slice(36,68)).toString('hex'),
+    tx:                [],
+    time:              payload.readUInt32LE(68),
+    nonce:             payload.readUInt32LE(76),
+    bits:              inPlaceReverse(payload.slice(72,76)).toString('hex'),
+    difficulty:        undefined,
+    chainwork:         undefined,
+    previousblockhash: inPlaceReverse(payload.slice(4,36)).toString('hex'),
+  };
+
+  var txc = payload.readVarInt(80);
+
+  var i, base = 80+txc.size;
+
+  for ( i=0; i<txc.value; i++ ) {
+    var tx = this.parseTx(new P2PBuffer(payload.slice(base)));
+    content.tx.push(tx);
+    base +=  tx.hex.length / 2;
   }
 
-  return buf;
+
+  /*
+   * Get the bip-0034 height if the block version is greater than 1
+   * https://github.com/bitcoin/bips/blob/master/bip-0034.mediawiki
+   */
+  if ( content.version > 1 ) {
+    var coinbase = content.tx[0];
+    content.height = 0;
+
+    var script = new Buffer(coinbase.vin[0].coinbase,'hex');
+    var s = script.readUInt8(0);
+    for (i=0; i<s && i<3; i++) {
+      content.height += script.readUInt8(i+1) * ( i > 0 ? i*256 : 1);
+    }
+  }
+
+
+  return content;
 }
 
 P2PSocket.prototype.parseTx = function(payload) {
 
-  var sha256_pass1 = crypto.createHash('sha256').update(payload.toBuffer()).digest();
-  var txid = inPlaceReverse(crypto.createHash('sha256').update(sha256_pass1).digest()).toString('hex');
-
   var content = {
     version: payload.readUInt32LE(0),
-    hex:  payload.toString('hex'),
-    txid: txid,
+    hex:  null,
+    txid: null,
+    lock_time: null,
     vin:  [],
     vout: [],
   };
@@ -124,7 +181,7 @@ P2PSocket.prototype.parseTx = function(payload) {
   for ( n=0; n < cin.value; n++ ) {
 
     var tx = {
-      txid: inPlaceReverse(payload.slice(i, i+32)).toString('hex'),
+      txid: inPlaceReverse(payload.slice(i, i+32),true).toString('hex'),
       vout: payload.readUInt32LE(i+32)
     };
 
@@ -144,6 +201,13 @@ P2PSocket.prototype.parseTx = function(payload) {
     tx.sequence = payload.readUInt32LE(i);
     i += 4;
 
+    if ( tx.vout === tx.sequence && tx.txid.match(/^0+$/) ) {
+      tx = {
+        coinbase: tx.scriptSig.hex,
+        sequence: tx.sequence,
+      }
+    }
+
     content.vin.push(tx);
   }
 
@@ -153,7 +217,7 @@ P2PSocket.prototype.parseTx = function(payload) {
   for ( n=0; n < cout.value; n++ ) {
 
     var tx = {
-      value: payload.readInt64(i),
+      value: payload.readInt64(i) / this._divisor,
     };
 
     i += 8;
@@ -198,20 +262,31 @@ P2PSocket.prototype.parseTx = function(payload) {
 
   content.lock_time =  payload.readUInt32LE(i);
 
+  var raw = payload.slice(0,i+4);
+
+  var sha256_pass1 = crypto.createHash('sha256').update(raw).digest();
+  content.txid = inPlaceReverse(crypto.createHash('sha256').update(sha256_pass1).digest()).toString('hex');
+
+  content.hex = raw.toString('hex');
+
   return content;
 }
 
 P2PSocket.prototype.parse = function(method, payload) {
   switch( method ) {
-    case 'version': return this.parseVersion(payload);
-    case 'inv':     return this.parseInv(payload);
-    case 'tx':      return this.parseTx(payload);
-    default:        return null;
+    case 'version':  return this.parseVersion(payload);
+    case 'getdata':
+    case 'inv':
+    case 'notfound': return this.parseInv(payload);
+    case 'block':    return this.parseBlock(payload);
+    case 'tx':       return this.parseTx(payload);
+    default:         return null;
   }
 }
 
 P2PSocket.prototype.receive = function(data) {
   var buffer = new Buffer(data);
+  var headerSize = 24;
 
   var message = {
     raw: buffer
@@ -239,11 +314,61 @@ P2PSocket.prototype.receive = function(data) {
   message.content = this.parse(message.method, message.payload);
 
   this.emit('p2p_' + message.method, message.content);
-  return message;
+
+  if ( message.payload_length + headerSize < buffer.length ) {
+    this.receive(buffer.slice(message.payload_length + headerSize));
+
+  } else if ( message.payload_length + headerSize > buffer.length ) {
+    throw "Incomplete message";
+
+  }
+}
+
+/*
+ * Expected values of inventory:
+ *   [
+ *     { "type": 1, "hash": "e65efa60566..." },
+ *     ...
+ *   ]
+ *   or
+ *   [
+ *     { "type": 1, "hash": < Buffer 1b 82 f9 5f 7d 30 b9  ...>" },
+ *     ...
+ *   ]
+ * When using buffer the value of the buffer must be in little-endian byte order,
+ * which is the opposite of if you read the hex string left to right.
+ *
+ * Types are:
+ *   0 = error (ignored)
+ *   1 = transaction
+ *   2 = block
+ *   3 = filtered block
+ */
+P2PSocket.prototype.getdata = function( inventory ) {
+  var l = inventory.length;
+  var start = P2PBuffer.getVarIntSize(l);
+
+  var buffer = new P2PBuffer(l * 36 + start );
+
+  buffer.writeVarInt(l);
+
+  var i;
+  for ( i=0; i < l; i++ ) {
+    buffer.writeUInt32LE( inventory[i].type, start + 36*i );
+
+    var hash = inventory[i].hash instanceof Buffer ? inventory[i].hash : inPlaceReverse(new Buffer(inventory[i].hash,'hex'));
+    hash.copy( buffer, start + 36*i + 4 );
+  }
+
+  this.sendPacket("getdata", buffer);
+}
+
+P2PSocket.prototype.mempool = function() {
+  this.sendPacket("mempool", new P2PBuffer(0));
 }
 
 P2PSocket.prototype.version = function() {
-  var userAgent = "/Ziftr Skinny Peer:0.1/";
+  var userAgent = "/Ziftr Skinny Peer:0.2/";
 
   var size = 85 + P2PBuffer.getVarStrSize(userAgent);
   var buffer = new P2PBuffer(size);
@@ -279,24 +404,6 @@ P2PSocket.prototype.version = function() {
 
   this.sendPacket("version", buffer);
 }
-
-P2PSocket.prototype.getdata = function( inventory ) {
-  var l = inventory.length;
-  var start = P2PBuffer.getVarIntSize(l);
-
-  var buffer = new P2PBuffer(l * 36 + start );
-
-  buffer.writeVarInt(l);
-
-  var i;
-  for ( i=0; i < l; i++ ) {
-    buffer.writeUInt32LE( inventory[i].type, start + 36*i );
-    inventory[i].hash.copy( buffer, start + 36*i + 4 );
-  }
-
-  this.sendPacket("getdata", buffer);
-}
-
 
 P2PSocket.prototype.connect = function(port, host, connectListener) {
   var self = this;

--- a/lib/p2psocket.js
+++ b/lib/p2psocket.js
@@ -1,26 +1,31 @@
 'use strict';
 
 var P2PBuffer = require('./p2pbuffer.js').P2PBuffer;
+var scriptToAsm = require('./script.js').scriptToAsm;
+var opcodes = require('./script.js').opcodes;
+
 var net = require('net');
 var crypto = require('crypto');
 var util = require('util');
+var bs58 = require('bs58');
 
-var P2PSocket = function(magic) {
+var P2PSocket = function(magic, version) {
   this.constructor.super_.apply(this)
 
-  this.nonce = 1;
+  this._nonce = 1;
 
-  this.magic = magic;
-  
+  this._magic   = magic;
+  this._version = version || 0x6f;
+
   var _super_connect = this.connect;
-  
+
   this.on('data', this.receive);
 }
 
 util.inherits(P2PSocket, net.Socket);
 
 P2PSocket.prototype.sendPacket = function(method, payload) {
-  this.write(payload.packetHeader(this.magic,method));
+  this.write(payload.packetHeader(this._magic,method));
   this.write(payload.toBuffer());
 }
 
@@ -38,10 +43,10 @@ P2PSocket.prototype.parseVersion = function(payload) {
   content.timestamp   = new Date(payload.readInt64(i)*1000);
   i += 8;
 
-  content.addr_recv   = payload.readAddr(true, i);
+  content.addr_recv   = payload.readAddr(i);
   i += 26;
-  
-  content.addr_from   = payload.readAddr(true, i);
+
+  content.addr_from   = payload.readAddr(i);
   i += 26;
 
   content.nonce       = payload.readInt64(i);
@@ -84,63 +89,114 @@ P2PSocket.prototype.parseInv = function(payload) {
   return content;
 }
 
+function inPlaceReverse(buf) {
+  var i, h = Math.ceil(buf.length/2), ii, tmp;
+
+  for ( i=0; i<h; i++ ) {
+    ii      = buf.length-i-1;
+    tmp     = buf[i];
+    buf[i]  = buf[ii];
+    buf[ii] = tmp;
+  }
+
+  return buf;
+}
+
 P2PSocket.prototype.parseTx = function(payload) {
+
+  var sha256_pass1 = crypto.createHash('sha256').update(payload.toBuffer()).digest();
+  var txid = inPlaceReverse(crypto.createHash('sha256').update(sha256_pass1).digest()).toString('hex');
+
   var content = {
     version: payload.readUInt32LE(0),
+    hex:  payload.toString('hex'),
+    txid: txid,
     vin:  [],
     vout: [],
   };
-  
+
   var i = 4;
-  
+
   var cin = payload.readVarInt(i);
   i += cin.size;
-  
+
   var n;
   for ( n=0; n < cin.value; n++ ) {
-  
+
     var tx = {
-      previous_output: {
-        txid: payload.slice(i, i+32),
-        vout: payload.readUInt32LE(i+32),
-      },
+      txid: inPlaceReverse(payload.slice(i, i+32)).toString('hex'),
+      vout: payload.readUInt32LE(i+32)
     };
-    
+
     i += 36;
-    
+
     var sl = payload.readVarInt(i);
     i += sl.size;
-    
-    tx.scriptSig = payload.slice(i, i+sl.value);
+
+    var scriptSig = payload.slice(i, i+sl.value);
+    tx.scriptSig = {
+      hex: scriptSig.toString('hex'),
+      asm: scriptToAsm(scriptSig),
+    }
+
     i += sl.value;
-    
+
     tx.sequence = payload.readUInt32LE(i);
     i += 4;
-    
-    content.vin.push(tx);      
+
+    content.vin.push(tx);
   }
 
   var cout = payload.readVarInt(i);
   i += cout.size;
-  
+
   for ( n=0; n < cout.value; n++ ) {
-  
+
     var tx = {
       value: payload.readInt64(i),
     };
-    
+
     i += 8;
-    
+
     var pkl = payload.readVarInt(i);
     i += pkl.size;
-    
-    tx.scriptPubKey = payload.slice(i, i+pkl.value);
+
+    var scriptPubKey = payload.slice(i, i+pkl.value);
+    tx.scriptPubKey = {
+      hex: scriptPubKey.toString('hex'),
+      asm: scriptToAsm(scriptPubKey),
+    }
+
+    if ( scriptPubKey.length === 25 && scriptPubKey[0] === opcodes.OP_DUP &&
+         scriptPubKey[1] === opcodes.OP_HASH160 && scriptPubKey[2] === 20 &&
+         scriptPubKey[23] === opcodes.OP_EQUALVERIFY &&
+         scriptPubKey[24] === opcodes.OP_CHECKSIG
+     ) {
+      tx.scriptPubKey.reqSigs = 1;
+      tx.scriptPubKey.type = 'pubkeyhash';
+
+      var hash = scriptPubKey.slice( 3, 23 );
+
+      var addrBuf = new Buffer( hash.length + 1 );
+      addrBuf[0] = this._version;
+      hash.copy( addrBuf, 1, 0 );
+
+      var sha256_pass1 = crypto.createHash('sha256').update(addrBuf).digest();
+      var sha256 = crypto.createHash('sha256').update(sha256_pass1).digest();
+
+      tx.scriptPubKey.addresses = [
+        bs58.encode( Buffer.concat( [addrBuf, sha256.slice(0,4)], addrBuf.length + 4 ) )
+      ];
+    }
+
     i += pkl.value;
-    
+
     tx.n = n;
-    
-    content.vout.push(tx);      
+
+    content.vout.push(tx);
   }
+
+  content.lock_time =  payload.readUInt32LE(i);
 
   return content;
 }
@@ -162,8 +218,8 @@ P2PSocket.prototype.receive = function(data) {
   };
 
   var i = 0;
-  message.magic  = buffer.slice(0,this.magic.length);
-  i += this.magic.length;
+  message.magic  = buffer.slice(0,this._magic.length);
+  i += this._magic.length;
 
   message.method = buffer.slice(i,i+12).toString('ascii').replace(/\0+$/,'');
   i += 12;
@@ -193,7 +249,7 @@ P2PSocket.prototype.version = function() {
   var buffer = new P2PBuffer(size);
   var i = 0;
 
-  this.nonce++;
+  this._nonce++;
 
   buffer.writeUInt32LE(0x60002, i);
   i += 4;
@@ -204,13 +260,13 @@ P2PSocket.prototype.version = function() {
   buffer.writeInt64(new Date().getTime(), i);
   i += 8;
 
-  buffer.writeAddr(true, this.remoteAddress, this.remotePort, i);
-  i += 26;
-  
-  buffer.writeAddr(true, this.localAddress,  this.localPort,  i);
+  buffer.writeAddr(this.remoteAddress, this.remotePort, i);
   i += 26;
 
-  buffer.writeInt64(this.nonce, i);
+  buffer.writeAddr(this.localAddress,  this.localPort,  i);
+  i += 26;
+
+  buffer.writeInt64(this._nonce, i);
   i += 8;
 
   buffer.writeVarStr(userAgent, i);
@@ -229,15 +285,15 @@ P2PSocket.prototype.getdata = function( inventory ) {
   var start = P2PBuffer.getVarIntSize(l);
 
   var buffer = new P2PBuffer(l * 36 + start );
-  
+
   buffer.writeVarInt(l);
-      
+
   var i;
   for ( i=0; i < l; i++ ) {
     buffer.writeUInt32LE( inventory[i].type, start + 36*i );
     inventory[i].hash.copy( buffer, start + 36*i + 4 );
   }
-  
+
   this.sendPacket("getdata", buffer);
 }
 

--- a/lib/p2psocket.js
+++ b/lib/p2psocket.js
@@ -27,13 +27,13 @@ function inPlaceReverse(buf, copy) {
   return buf;
 }
 
-var P2PSocket = function(magic, version, divisor) {
+var P2PSocket = function(magic, p2pkh_byte, divisor) {
   this.constructor.super_.apply(this)
 
   this._nonce = 1;
 
   this._magic   = magic;
-  this._version = version || 0x6f;
+  this._p2pkh_byte = p2pkh_byte || 0x6f;
   this._divisor = divisor || 100000000;
 
   var _super_connect = this.connect;
@@ -242,7 +242,7 @@ P2PSocket.prototype.parseTx = function(payload) {
       var hash = scriptPubKey.slice( 3, 23 );
 
       var addrBuf = new Buffer( hash.length + 1 );
-      addrBuf[0] = this._version;
+      addrBuf[0] = this._p2pkh_byte;
       hash.copy( addrBuf, 1, 0 );
 
       var sha256_pass1 = crypto.createHash('sha256').update(addrBuf).digest();

--- a/lib/script.js
+++ b/lib/script.js
@@ -1,0 +1,194 @@
+'use strict';
+
+var opcodes = {
+  // push value
+  'OP_0' : 0x00,
+  'OP_FALSE' : 'OP_0',
+  'OP_PUSHDATA1' : 0x4c,
+  'OP_PUSHDATA2' : 0x4d,
+  'OP_PUSHDATA4' : 0x4e,
+  'OP_1NEGATE' : 0x4f,
+  'OP_RESERVED' : 0x50,
+  'OP_1' : 0x51,
+  'OP_TRUE':'OP_1',
+  'OP_2' : 0x52,
+  'OP_3' : 0x53,
+  'OP_4' : 0x54,
+  'OP_5' : 0x55,
+  'OP_6' : 0x56,
+  'OP_7' : 0x57,
+  'OP_8' : 0x58,
+  'OP_9' : 0x59,
+  'OP_10' : 0x5a,
+  'OP_11' : 0x5b,
+  'OP_12' : 0x5c,
+  'OP_13' : 0x5d,
+  'OP_14' : 0x5e,
+  'OP_15' : 0x5f,
+  'OP_16' : 0x60,
+
+  // control
+  'OP_NOP' : 0x61,
+  'OP_VER' : 0x62,
+  'OP_IF' : 0x63,
+  'OP_NOTIF' : 0x64,
+  'OP_VERIF' : 0x65,
+  'OP_VERNOTIF' : 0x66,
+  'OP_ELSE' : 0x67,
+  'OP_ENDIF' : 0x68,
+  'OP_VERIFY' : 0x69,
+  'OP_RETURN' : 0x6a,
+
+  // stack ops
+  'OP_TOALTSTACK' : 0x6b,
+  'OP_FROMALTSTACK' : 0x6c,
+  'OP_2DROP' : 0x6d,
+  'OP_2DUP' : 0x6e,
+  'OP_3DUP' : 0x6f,
+  'OP_2OVER' : 0x70,
+  'OP_2ROT' : 0x71,
+  'OP_2SWAP' : 0x72,
+  'OP_IFDUP' : 0x73,
+  'OP_DEPTH' : 0x74,
+  'OP_DROP' : 0x75,
+  'OP_DUP' : 0x76,
+  'OP_NIP' : 0x77,
+  'OP_OVER' : 0x78,
+  'OP_PICK' : 0x79,
+  'OP_ROLL' : 0x7a,
+  'OP_ROT' : 0x7b,
+  'OP_SWAP' : 0x7c,
+  'OP_TUCK' : 0x7d,
+
+  // splice ops
+  'OP_CAT' : 0x7e,
+  'OP_SUBSTR' : 0x7f,
+  'OP_LEFT' : 0x80,
+  'OP_RIGHT' : 0x81,
+  'OP_SIZE' : 0x82,
+
+  // bit logic
+  'OP_INVERT' : 0x83,
+  'OP_AND' : 0x84,
+  'OP_OR' : 0x85,
+  'OP_XOR' : 0x86,
+  'OP_EQUAL' : 0x87,
+  'OP_EQUALVERIFY' : 0x88,
+  'OP_RESERVED1' : 0x89,
+  'OP_RESERVED2' : 0x8a,
+
+  // numeric
+  'OP_1ADD' : 0x8b,
+  'OP_1SUB' : 0x8c,
+  'OP_2MUL' : 0x8d,
+  'OP_2DIV' : 0x8e,
+  'OP_NEGATE' : 0x8f,
+  'OP_ABS' : 0x90,
+  'OP_NOT' : 0x91,
+  'OP_0NOTEQUAL' : 0x92,
+
+  'OP_ADD' : 0x93,
+  'OP_SUB' : 0x94,
+  'OP_MUL' : 0x95,
+  'OP_DIV' : 0x96,
+  'OP_MOD' : 0x97,
+  'OP_LSHIFT' : 0x98,
+  'OP_RSHIFT' : 0x99,
+
+  'OP_BOOLAND' : 0x9a,
+  'OP_BOOLOR' : 0x9b,
+  'OP_NUMEQUAL' : 0x9c,
+  'OP_NUMEQUALVERIFY' : 0x9d,
+  'OP_NUMNOTEQUAL' : 0x9e,
+  'OP_LESSTHAN' : 0x9f,
+  'OP_GREATERTHAN' : 0xa0,
+  'OP_LESSTHANOREQUAL' : 0xa1,
+  'OP_GREATERTHANOREQUAL' : 0xa2,
+  'OP_MIN' : 0xa3,
+  'OP_MAX' : 0xa4,
+
+  'OP_WITHIN' : 0xa5,
+
+  // crypto
+  'OP_RIPEMD160' : 0xa6,
+  'OP_SHA1' : 0xa7,
+  'OP_SHA256' : 0xa8,
+  'OP_HASH160' : 0xa9,
+  'OP_HASH256' : 0xaa,
+  'OP_CODESEPARATOR' : 0xab,
+  'OP_CHECKSIG' : 0xac,
+  'OP_CHECKSIGVERIFY' : 0xad,
+  'OP_CHECKMULTISIG' : 0xae,
+  'OP_CHECKMULTISIGVERIFY' : 0xaf,
+
+  // expansion
+  'OP_NOP1' : 0xb0,
+  'OP_CHECKLOCKTIMEVERIFY' : 0xb1,
+  'OP_NOP2' : 'OP_CHECKLOCKTIMEVERIFY',
+  'OP_NOP3' : 0xb2,
+  'OP_NOP4' : 0xb3,
+  'OP_NOP5' : 0xb4,
+  'OP_NOP6' : 0xb5,
+  'OP_NOP7' : 0xb6,
+  'OP_NOP8' : 0xb7,
+  'OP_NOP9' : 0xb8,
+  'OP_NOP10' : 0xb9,
+
+  // template matching params
+  'OP_SMALLINTEGER' : 0xfa,
+  'OP_PUBKEYS' : 0xfb,
+  'OP_PUBKEYHASH' : 0xfd,
+  'OP_PUBKEY' : 0xfe,
+
+  'OP_INVALIDOPCODE' : 0xff,
+};
+
+(function() {
+  var k;
+  for ( k in opcodes ) { opcodes[opcodes[k]] = k; }
+})();
+
+exports.opcodes = opcodes;
+
+var opcodeToString = exports.opcodeToString = function ( opcode ) {
+  return exports.opcodes[ opcode ] || 'OP_INVALIDOPCODE';
+}
+
+exports.scriptToAsm = function ( script ) {
+  if ( !(script instanceof Buffer ) ) {
+    throw "scriptToAsm takes a Buffer instance";
+  }
+
+  var result = '', l = script.length, i;
+
+  for ( i=0; i < l; i++ ) {
+    if ( i > 0 ) {
+      result += " ";
+    }
+
+    if ( script[i] > 0 && script[i] <= 75 ) {
+      result += script.slice( i + 1, i + 1 + script[i] ).toString('hex');
+      i += script[i];
+
+    } else if ( script[i] === opcodes.OP_PUSHDATA1 ) {
+      var len = script[i+1];
+      result += script.slice( i + 2, i + 2 + len ).toString('hex');
+      i += len + 1;
+
+    } else if ( script[i] === opcodes.OP_PUSHDATA2 ) {
+      var len = script.readUInt16LE(i+1);
+      result += script.slice( i + 3, i + 3 + len ).toString('hex');
+      i += len + 2;
+
+    } else if ( script[i] === opcodes.OP_PUSHDATA4 ) {
+      var len = script.readUInt32LE(i+1);
+      result += script.slice( i + 5, i + 5 + len ).toString('hex');
+      i += len + 4;
+
+    } else {
+      result += opcodeToString( script[i] );
+    }
+  }
+
+  return result;
+}

--- a/package.json
+++ b/package.json
@@ -1,21 +1,68 @@
 {
-  "name": "cryptocurrency.js",
-  "author": "Ziftr",
-  "description": "",
-  "version": "0.0.0",
-  "private": true,
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/Ziftr/cryptocurrency.js"
+  "_args": [
+    [
+      "cryptocurrency.js@git://github.com/Ziftr/cryptocurrency.js.git",
+      "/opt/code/src"
+    ]
+  ],
+  "_from": "git://github.com/Ziftr/cryptocurrency.js.git",
+  "_id": "cryptocurrency.js@0.0.0",
+  "_inCache": true,
+  "_installable": true,
+  "_location": "/cryptocurrency.js",
+  "_phantomChildren": {},
+  "_requested": {
+    "hosted": {
+      "directUrl": "https://raw.githubusercontent.com/Ziftr/cryptocurrency.js/master/package.json",
+      "gitUrl": "git://github.com/Ziftr/cryptocurrency.js.git",
+      "httpsUrl": "git+https://github.com/Ziftr/cryptocurrency.js.git",
+      "shortcut": "github:Ziftr/cryptocurrency.js",
+      "ssh": "git@github.com:Ziftr/cryptocurrency.js.git",
+      "sshUrl": "git+ssh://git@github.com/Ziftr/cryptocurrency.js.git",
+      "type": "github"
+    },
+    "name": "cryptocurrency.js",
+    "raw": "cryptocurrency.js@git://github.com/Ziftr/cryptocurrency.js.git",
+    "rawSpec": "git://github.com/Ziftr/cryptocurrency.js.git",
+    "scope": null,
+    "spec": "git://github.com/Ziftr/cryptocurrency.js.git",
+    "type": "hosted"
+  },
+  "_requiredBy": [
+    "/"
+  ],
+  "_resolved": "git://github.com/Ziftr/cryptocurrency.js.git#e21633867da1946c19fedbc8f6ac16770acb0387",
+  "_shasum": "8d71ef1a18b936cb37ff9ed8629dc0a0cb27d0c9",
+  "_shrinkwrap": null,
+  "_spec": "cryptocurrency.js@git://github.com/Ziftr/cryptocurrency.js.git",
+  "_where": "/opt/code/src",
+  "author": {
+    "name": "Ziftr"
+  },
+  "bugs": {
+    "url": "https://github.com/Ziftr/cryptocurrency.js/issues"
   },
   "dependencies": {
+    "bignum": "~0.11.0",
     "bluebird": "^2.9.8",
-    "lodash": "^3.1.0",
-    "bignum": "~0.11.0"
+    "bs58": "^3.0.0",
+    "lodash": "^3.1.0"
   },
-  "devDependencies": {
-  },
+  "description": "Library for connecting to blockchain peers",
+  "devDependencies": {},
+  "gitHead": "e21633867da1946c19fedbc8f6ac16770acb0387",
+  "homepage": "https://github.com/Ziftr/cryptocurrency.js#readme",
   "jshintConfig": {
     "node": true
-  }
+  },
+  "name": "cryptocurrency.js",
+  "optionalDependencies": {},
+  "private": true,
+  "readme": "# cryptocurrency.js\n\nLibrary for connecting to blockchain peers\n\n## Overview\n\nDesigned to open a socket to a locally running blockchain server and monitor for new blocks. Simulates 'push requests' behavior.\n",
+  "readmeFilename": "README.md",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Ziftr/cryptocurrency.js.git"
+  },
+  "version": "0.0.0"
 }


### PR DESCRIPTION
Parsing for more packet types:
- `getdata`
- `inv` (improved)
- `notfound`
- `tx`
- `block`

Also:
- New methods to call `getdata` on the client
- Basic script parsing
- Mostly bitcoind compatible output from parse ( does not handle pay to script hash and multisig correctly yet )
- Upgraded to use newest Node.js **backwards incompatible with older versions due to discrepancies in how to override `Buffer`**
